### PR TITLE
Fix blocking error

### DIFF
--- a/SynOblivionInteractionIcons/Program.cs
+++ b/SynOblivionInteractionIcons/Program.cs
@@ -42,10 +42,7 @@ namespace SynOblivionInteractionIcons
         {
             return await SynthesisPipeline.Instance
                 .AddPatch<ISkyrimMod, ISkyrimModGetter>(RunPatch)
-                .SetTypicalOpen(GameRelease.SkyrimSE, "OblivionInteractionIcons.esp").AddRunnabilityCheck(state =>
-                {
-                    state.LoadOrder.AssertHasMod(KeyOblivIcon, true, "\n\nskymojibase.esl missing!\n\n");
-                })
+                .SetTypicalOpen(GameRelease.SkyrimSE, "OblivionInteractionIcons.esp")
                 .Run(args);
         }
 

--- a/SynOblivionInteractionIcons/SynthesisMeta.json
+++ b/SynOblivionInteractionIcons/SynthesisMeta.json
@@ -4,5 +4,5 @@
   "OneLineDescription": "",
   "LongDescription": "",
   "PreferredAutoVersioning": "Default",
-  "RequiredMods": ["OblivionInteractionIcons.esp"]
+  "RequiredMods": ["skymoji.esp"]
 }

--- a/SynOblivionInteractionIcons/SynthesisMeta.json
+++ b/SynOblivionInteractionIcons/SynthesisMeta.json
@@ -1,0 +1,8 @@
+{
+  "Nickname": "OblivionInteractionIcons",
+  "Visibility": "IncludeButHide",
+  "OneLineDescription": "",
+  "LongDescription": "",
+  "PreferredAutoVersioning": "Default",
+  "RequiredMods": ["OblivionInteractionIcons.esp"]
+}


### PR DESCRIPTION
Fixes the following error:
```
Program.cs(47,37): error CS1061: 'ILoadOrderGetter<ILoadOrderListingGetter>' does not contain a definition for 'AssertHasMod' and no accessible extension method 'AssertHasMod' accepting a first argument of type 'ILoadOrderGetter<ILoadOrderListingGetter>' could be found (are you missing a using directive or an assembly reference?)
```
by switching to a synthesis meta file that requires the correct plugin (the plugin name has changed)